### PR TITLE
Fixes issue #17 - Using ProjectTool fails on non-Windows platform.

### DIFF
--- a/src/cake/library/project.py
+++ b/src/cake/library/project.py
@@ -23,7 +23,16 @@ from cake.target import FileTarget, getPath, getPaths
 from cake.async import getResult, waitForAsyncResult, flatten
 from cake.library import Tool
 from cake.script import Script
-from cake.library.compilers.msvc import MsvcCompiler
+
+try:
+  from cake.library.compilers.msvc import MsvcCompiler
+except ImportError:
+  # This import will fail on platforms without the Windows registry.
+  #
+  # Given the tool can't be imported it can't be in use so the checking
+  # performed below would never succeed.
+  class MsvcCompiler(object):
+    pass
 
 class _Project(object):
 


### PR DESCRIPTION
The problem is the ProjectTool attempts to determine if the compiler is
MSVC, to do this it tries to import the module with the MsvcCompiler.
On platforms without the Windows Registry (like Linux), the user is faced
with an import error for _winreg.

The import error is now caught and a type is defined to satisfy the check.

At this time MsvcCompiler isn't supported outside of Microsoft Windows.

This possibly could be reevaluated in the future as Compiler Explorer by Matt Godbolt seems to demonstrate that running the compiler on Linux via Wine is a technical possibility. Whether that it is possibly within the standard end user licensee is another question (Matt may have been granted additional rights due to the nature and popularity of his tool).