### PR TITLE
Propagate the don't write bytecode files flag to generated projects.

### DIFF
--- a/src/cake/library/project.py
+++ b/src/cake/library/project.py
@@ -589,6 +589,12 @@ class ProjectTool(Tool):
         cake.path.relativePath(cakeScript, targetDir),
         scriptArg,
         ]
+
+      # Propgate the option (at the time of project generation) to suppress
+      # bytecode files when building from the projects.
+      if sys.dont_write_bytecode:
+        buildArgs.insert(1, "-B")
+
       buildArgs.extend("=".join([k, v]) for k, v in keywords.iteritems())
 
       try:


### PR DESCRIPTION
If bytecode files are not written out when building projects then that option is propagated through to th generated projects. This means when building from Visual Studio, it too won't write out the bytecode files.

Without this change, you will likely find yourselves having no .cakec files written out when building from
a terminal but after building from Visual Studio, the files will be created.