### PR TITLE
Update msvs.py

### DIFF
--- a/src/cake/msvs.py
+++ b/src/cake/msvs.py
@@ -184,7 +184,7 @@ def vswhere(args=[]):
     raise EnvironmentError("vswhere not found at " + vsWherePath)
 
   p = subprocess.Popen(
-    args=["vswhere", "-format", "json"] + args,
+    args=["vswhere", "-format", "json", "-utf8"] + args,
     executable=vsWherePath,
     cwd=vsInstaller,
     stdout=subprocess.PIPE,
@@ -196,4 +196,4 @@ def vswhere(args=[]):
   if p.returncode != 0:
     raise EnvironmentError("vswhere: returned with exit code " + str(p.returncode) + "\n" + out)
 
-  return json.loads(re.sub(r'[^\x00-\x7F]', ' ', out))
+  return json.loads(out.decode("utf8"))

--- a/src/cake/msvs.py
+++ b/src/cake/msvs.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import _winreg as winreg
+import re
 
 import cake.path
 import cake.system
@@ -195,4 +196,4 @@ def vswhere(args=[]):
   if p.returncode != 0:
     raise EnvironmentError("vswhere: returned with exit code " + str(p.returncode) + "\n" + out)
 
-  return json.loads(out)
+  return json.loads(re.sub(r'[^\x00-\x7F]', ' ', out))

--- a/src/cake/msvs.py
+++ b/src/cake/msvs.py
@@ -8,7 +8,6 @@ import json
 import os
 import subprocess
 import _winreg as winreg
-import re
 
 import cake.path
 import cake.system


### PR DESCRIPTION
Fixes an issue when vswhere may return characters outside the [00-127] range (an example may be the description param having some polish special characters). json.loads fails without this change in this way: 

  File "E:\conan-packages\cppcoro\tools\cake\src\cake\msvs.py", line 201, in vswhere
    return json.loads(out)
  File "E:\Python\Python27\lib\json\__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "E:\Python\Python27\lib\json\decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "E:\Python\Python27\lib\json\decoder.py", line 380, in raw_decode
    obj, end = self.scan_once(s, idx)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xa2 in position 58: invalid start byte

I don't say it's needed to be done this way, i'm just not proficient enough in python.